### PR TITLE
fixed link issues on aarch64 musl

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-musl]
+rustflags = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc"]


### PR DESCRIPTION
The linker was unable to find __addtf3, __multf3 and __subtf3.

Added target-feature=+crt-static and link-arg=-lgcc as a temporary
workaround. This seems to be the accepted fix in the Rust community:
rust-lang-nursery/compiler-builtins#201

A permanent fix is yet to be implemented in the Rust compiler.

Signed-off-by: Andreea Florescu <fandree@amazon.com>